### PR TITLE
add jscs and jshint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ keystore.jks
 TODO
 .sbtserver*
 .vagrant
+node_modules

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,4 @@
+{
+  "preset": "airbnb",
+  "requireCurlyBraces": null
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,4 @@
 {
-  // JSHint Default Configuration File (as on JSHint website)
-  // See http://jshint.com/docs/ for more details
 
   "maxerr"        : 5,       // {int} Maximum error before stopping
 

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,78 @@
+{
+  // JSHint Default Configuration File (as on JSHint website)
+  // See http://jshint.com/docs/ for more details
+
+  "maxerr"        : 5,       // {int} Maximum error before stopping
+
+  // Enforcing
+  "bitwise"       : true,     // true: Prohibit bitwise operators (&, |, ^, etc.)
+  "camelcase"     : true,    // true: Identifiers must be in camelCase
+  "curly"         : true,     // true: Require {} for every new block or scope
+  "eqeqeq"        : true,     // true: Require triple equals (===) for comparison
+  "forin"         : false,    // true: Require filtering for..in loops with obj.hasOwnProperty()
+  "freeze"        : true,     // true: prohibits overwriting prototypes of native objects such as Array, Date etc.
+  "immed"         : false,    // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
+  "latedef"       : true,     // true: Require variables/functions to be defined before being used
+  "newcap"        : true,    // true: Require capitalization of all constructor functions e.g. `new F()`
+  "noarg"         : true,     // true: Prohibit use of `arguments.caller` and `arguments.callee`
+  "noempty"       : true,     // true: Prohibit use of empty blocks
+  "nonbsp"        : true,     // true: Prohibit "non-breaking whitespace" characters.
+  "nonew"         : false,    // true: Prohibit use of constructors for side-effects (without assignment)
+  "plusplus"      : true,     // true: Prohibit use of `++` and `--`
+  "quotmark"      : false,    // Quotation mark consistency:
+                              //   false    : do nothing (default)
+                              //   true     : ensure whatever is used is consistent
+                              //   "single" : require single quotes
+                              //   "double" : require double quotes
+  "undef"         : true,     // true: Require all non-global variables to be declared (prevents global leaks)
+  "unused"        : true,     // Unused variables:
+                              //   true     : all variables, last function parameter
+                              //   "vars"   : all variables only
+                              //   "strict" : all variables, all function parameters
+  "strict"        : true,     // true: Requires all functions run in ES5 Strict Mode
+  "maxparams"     : false,    // {int} Max number of formal params allowed per function
+  "maxdepth"      : false,    // {int} Max depth of nested blocks (within functions)
+  "maxstatements" : false,    // {int} Max number statements per function
+  "maxcomplexity" : false,    // {int} Max cyclomatic complexity per function
+  "maxlen"        : 80,       // {int} Max number of characters per line
+  "varstmt"       : false,    // true: Disallow any var statements. Only `let` and `const` are allowed.
+
+  // Relaxing
+  "asi"           : true,      // true: Tolerate Automatic Semicolon Insertion (no semicolons)
+  "boss"          : false,     // true: Tolerate assignments where comparisons would be expected
+  "debug"         : false,     // true: Allow debugger statements e.g. browser breakpoints.
+  "eqnull"        : false,     // true: Tolerate use of `== null`
+  "es5"           : true,      // true: Allow ES5 syntax (ex: getters and setters)
+  "esnext"        : false,     // true: Allow ES.next (ES6) syntax (ex: `const`)
+  "moz"           : false,     // true: Allow Mozilla specific syntax (extends and overrides esnext features)
+  // (ex: `for each`, multiple try/catch, function expression…)
+  "evil"          : false,     // true: Tolerate use of `eval` and `new Function()`
+  "expr"          : false,     // true: Tolerate `ExpressionStatement` as Programs
+  "funcscope"     : false,     // true: Tolerate defining variables inside control statements
+  "globalstrict"  : false,     // true: Allow global "use strict" (also enables 'strict')
+  "iterator"      : false,     // true: Tolerate using the `__iterator__` property
+  "lastsemic"     : false,     // true: Tolerate omitting a semicolon for the last statement of a 1-line block
+  "laxbreak"      : false,     // true: Tolerate possibly unsafe line breakings
+  "laxcomma"      : false,     // true: Tolerate comma-first style coding
+  "loopfunc"      : false,     // true: Tolerate functions being defined in loops
+  "multistr"      : false,     // true: Tolerate multi-line strings
+  "noyield"       : false,     // true: Tolerate generator functions with no yield statement in them.
+  "notypeof"      : false,     // true: Tolerate invalid typeof operator values
+  "proto"         : false,     // true: Tolerate using the `__proto__` property
+  "scripturl"     : false,     // true: Tolerate script-targeted URLs
+  "shadow"        : false,     // true: Allows re-define variables later in code e.g. `var x=1; x=2;`
+  "sub"           : false,     // true: Tolerate using `[]` notation when it can still be expressed in dot notation
+  "supernew"      : false,     // true: Tolerate `new function () { ... };` and `new Object;`
+  "validthis"     : false,     // true: Tolerate using this in a non-constructor function
+
+  // Environments
+  "browser"       : true,     // Web Browser (window, document, etc)
+  "jquery"        : false,    // jQuery
+
+  // Custom Globals
+  "globals"       : {
+    "$": true,
+    "App": true,
+    "jsRoutes": true
+  }
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,29 @@
+
+var gulp = require('gulp'),
+    $ = require('gulp-load-plugins')();
+
+// Javascript code style - .jscsrc ( http://jscs.info/rules )
+gulp.task('jscs', function() {
+    return gulp.src('app/**/*.js')
+        .pipe($.jscs())
+        .pipe($.jscs.reporter());
+});
+
+// Javascript hint - .jshintrc (http://jshint.com/docs/options/)
+gulp.task('jshint', function() {
+    return gulp.src('app/**/*.js')
+        .pipe($.jshint())
+        .pipe($.jshint.reporter('default'))
+});
+
+
+// Watch task
+gulp.task('serve', ['jscs'], function () {
+    gulp.watch('app/**/*.js', ['jscs']);
+});
+
+
+//Default task
+gulp.task('default', function () {
+    gulp.start('serve');
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "teller",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "dev": "gulp serve"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/HappyMelly/teller.git"
+  },
+  "author": "Happy Melly Teller",
+  "license": "GNU General Public License v.3",
+  "bugs": {
+    "url": "https://github.com/HappyMelly/teller/issues"
+  },
+  "homepage": "https://github.com/HappyMelly/teller#readme",
+  "devDependencies": {
+    "gulp": "^3.9.0",
+    "gulp-jscs": "^3.0.2",
+    "gulp-jshint": "^2.0.0",
+    "gulp-load-plugins": "^1.2.0",
+    "jshint": "^2.8.0"
+  }
+}


### PR DESCRIPTION
Добавил 
1) Javascript codestyle(http://jscs.info/rules), все настройки хранятся в .jscsrc (примеры https://github.com/jscs-dev/node-jscs/tree/master/presets)
2) JsHint (http://jshint.com/docs/) - для нахождения возможных ошибок, конфиг я сделал, но пока отключил, так как много замечаний выдает
3) gulp(http://gulpjs.com/) - менеджерит все эти задачи и мало ли другие потом появятся
npm i  - в корне проекта, чтобы установить все зависимости
и далее выполнение задач:
gulp jscs - запускает проверку стиля написания js
gulp jshint - запускает jshint